### PR TITLE
[feature] loadScriptsFromObject to load Scripts collection from external

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -9,6 +9,7 @@ module.exports = function() {
     var scripts = [];
     var triggers = [];
     var PATH_TO_SCRIPTS;
+    var LOAD_FROM_OBJECT;
 
     api.parseAdminUsers = function(string) {
         if (!string) {
@@ -25,6 +26,16 @@ module.exports = function() {
 
         return users;
 
+    }
+
+    api.loadScriptsFromObject = function (object) {
+        return new Promise(function (resolve, reject) {
+            scripts = object;
+            PATH_TO_SCRIPTS = null;
+            LOAD_FROM_OBJECT = true;
+            api.mapTriggers();
+            resolve(scripts);
+        });
     }
 
     api.loadScriptsFromFile = function(src, alt_path) {
@@ -54,6 +65,10 @@ module.exports = function() {
     api.writeScriptsToFile = function(new_scripts, alt_path) {
 
         return new Promise(function(resolve, reject) {
+            if (!PATH_TO_SCRIPTS && LOAD_FROM_OBJECT) {
+                return reject('Cannot save to file when using loadScriptsFromObject')
+            }
+
             try {
                 require('fs').writeFileSync(alt_path || PATH_TO_SCRIPTS, JSON.stringify(new_scripts,null,2));
             } catch(err) {


### PR DESCRIPTION
The loadScriptsFromObject function makes it possible to initiaize botkit-cms without directly accessing the filesystem. This can be utilized in environments such as webpack or rollup, where server code is self-contained. When using loadScriptsFromObject the ability to write / save script files is disabled.
* enables support for external storage of script files
* allows for dynamic botkit-cms script loading based on things such as user ids or userflags
* creates an option to avoid an fs dependency in stateless environments