### PR TITLE
Added node command to js scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
   },
   "scripts": {
     "start": "node index.js",
-    "build": "./node_modules/gulp/bin/gulp.js",
-    "gulp": "./node_modules/gulp/bin/gulp.js",
-    "eslint": "./node_modules/eslint/bin/eslint.js js/ src/ components/",
+    "build": "node ./node_modules/gulp/bin/gulp.js",
+    "gulp": "node ./node_modules/gulp/bin/gulp.js",
+    "eslint": "node ./node_modules/eslint/bin/eslint.js js/ src/ components/",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {


### PR DESCRIPTION
Fix for issue #18. Added node command to build, gulp, and eslint scripts. Should prevent error "'.' is not recognized as an internal or external command, operable program, or batch file".